### PR TITLE
Add labels and comments count to ToolResource

### DIFF
--- a/app/Filament/Resources/ToolResource.php
+++ b/app/Filament/Resources/ToolResource.php
@@ -55,9 +55,11 @@ class ToolResource extends Resource
                     ->required(),
 
                 TextInput::make('url')
+                    ->label('URL')
                     ->url(),
 
                 TextInput::make('git_repo_url')
+                    ->label('Git Repo URL')
                     ->url(),
 
                 Grid::make()
@@ -139,6 +141,10 @@ class ToolResource extends Resource
                 TextColumn::make('has_affiliate')
                     ->label('Affiliate')
                     ->formatStateUsing(fn (string $state, ?Tool $record): string => $record->affiliate),
+
+                TextColumn::make('filament_comments_count')
+                    ->label('Comments')
+                    ->counts('filamentComments'),
             ])
             ->filters([
                 //


### PR DESCRIPTION
Added explicit labels to the 'url' and 'git_repo_url' fields in the form for clarity. Introduced a new 'Comments' column in the table to display the count of related 'filamentComments'.