### PR TITLE
Add tools stats and charts to dashboard widgets

### DIFF
--- a/app/Filament/Resources/DashboardResource/Widgets/StatsOverview.php
+++ b/app/Filament/Resources/DashboardResource/Widgets/StatsOverview.php
@@ -7,6 +7,7 @@ use App\Models\Certification;
 use App\Models\Company;
 use App\Models\Course;
 use App\Models\Resource;
+use App\Models\Tool;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Number;
@@ -25,6 +26,9 @@ class StatsOverview extends BaseWidget
             Stat::make('Resources', Number::abbreviate(Resource::count(), maxPrecision: 3))
                 ->description('Total resources')
                 ->descriptionIcon('heroicon-s-cpu-chip'),
+            Stat::make('Tools', Number::abbreviate(Tool::count(), maxPrecision: 3))
+                ->description('Total tools')
+                ->descriptionIcon('heroicon-s-wrench-screwdriver'),
             Stat::make('Certifications', Number::abbreviate(Certification::count(), maxPrecision: 3))
                 ->description('Total certifications')
                 ->descriptionIcon('heroicon-s-sparkles'),

--- a/app/Filament/Resources/DashboardResource/Widgets/ToolTypesChart.php
+++ b/app/Filament/Resources/DashboardResource/Widgets/ToolTypesChart.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Resources\DashboardResource\Widgets;
+
+use App\Models\ToolType;
+use Filament\Widgets\ChartWidget;
+
+class ToolTypesChart extends ChartWidget
+{
+    protected static ?string $heading = 'Tool types';
+
+    protected static ?string $pollingInterval = null;
+
+    protected static string $color = 'info';
+
+    protected function getData(): array
+    {
+        $countsArray = ToolType::withCount('tools')
+            ->get()
+            ->pluck('tools_count', 'name')
+            ->toArray();
+
+        $label = [];
+        $data = [];
+
+        foreach ($countsArray as $key => $value) {
+            $label[] = $key;
+            $data[] = $value;
+        }
+
+        //dd($label, $data);
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Tool types',
+                    'data' => $data,
+                ],
+            ],
+            'labels' => $label,
+        ];
+    }
+
+    public function getDescription(): ?string
+    {
+        return 'Show the count of tools for each tool type';
+    }
+
+    protected function getType(): string
+    {
+        return 'doughnut';
+    }
+}

--- a/app/Filament/Resources/DashboardResource/Widgets/ToolsChart.php
+++ b/app/Filament/Resources/DashboardResource/Widgets/ToolsChart.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Resources\DashboardResource\Widgets;
+
+use App\Models\Tool;
+use Filament\Widgets\ChartWidget;
+
+class ToolsChart extends ChartWidget
+{
+    protected static ?string $heading = 'Tools Components';
+
+    protected static ?string $pollingInterval = null;
+
+    protected function getData(): array
+    {
+        $counts = Tool::selectRaw('
+            COUNT(CASE WHEN is_saas = 1 THEN 1 END) as saas_count,
+            COUNT(CASE WHEN is_self_hosted = 1 THEN 1 END) as self_hosted_count,
+            COUNT(CASE WHEN is_open_source = 1 THEN 1 END) as open_source_count,
+            COUNT(CASE WHEN has_api = 1 THEN 1 END) as api_count,
+            COUNT(CASE WHEN has_free_tier = 1 THEN 1 END) as free_tier_count,
+            COUNT(CASE WHEN has_affiliate = 1 THEN 1 END) as affiliate_count
+        ')->first();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Tools features',
+                    'data' => [
+                        $counts->saas_count,
+                        $counts->self_hosted_count,
+                        $counts->open_source_count,
+                        $counts->api_count,
+                        $counts->free_tier_count,
+                        $counts->affiliate_count,
+                    ],
+                ],
+            ],
+            'labels' => [
+                'SaaS',
+                'Self-hosted',
+                'Open-source',
+                'API',
+                'Free-tier',
+                'Affiliate',
+            ]
+        ];
+    }
+
+    public function getDescription(): ?string
+    {
+        return 'Show count of tools with listed features';
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Providers/Filament/UserPanelProvider.php
+++ b/app/Providers/Filament/UserPanelProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers\Filament;
 use App\Enums\NavigationGroup as NavigationGroupEnum;
 use App\Filament\Pages\EditProfile;
 use App\Filament\Resources\DashboardResource\Widgets\StatsOverview;
+use App\Filament\Resources\DashboardResource\Widgets\ToolsChart;
+use App\Filament\Resources\DashboardResource\Widgets\ToolTypesChart;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -39,6 +41,8 @@ class UserPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([
                 StatsOverview::class,
+                ToolsChart::class,
+                ToolTypesChart::class,
             ])
             ->middleware([
                 EncryptCookies::class,


### PR DESCRIPTION
Added a tools count stat to the StatsOverview widget. Introduced new ToolsChart and ToolTypesChart widgets to visualize tool features and tool type distributions. Registered the new widgets in the user panel provider for display on the dashboard.