### PR TITLE
Limit and sort tags in TagsChart widget

### DIFF
--- a/app/Filament/Resources/DashboardResource/Widgets/TagsChart.php
+++ b/app/Filament/Resources/DashboardResource/Widgets/TagsChart.php
@@ -25,12 +25,21 @@ class TagsChart extends ChartWidget
 
     protected function getData(): array
     {
-        $counts = Tag::select('tags.*', DB::raw('COUNT(taggables.tag_id) as models_count'))
+        $countItems = Tag::select('tags.*', DB::raw('COUNT(taggables.tag_id) as models_count'))
             ->leftJoin('taggables', 'tags.id', '=', 'taggables.tag_id')
             ->groupBy('tags.id')
             ->get()
+            ->sortByDesc('models_count')
+            ->take(30)
             ->pluck('models_count', 'name')
             ->toArray();
+
+        $counts = [];
+        foreach ($countItems as $key => $value) {
+            $counts[ucwords($key)] = $value;
+        }
+
+        ksort($counts, SORT_FLAG_CASE);
 
         $label = [];
         $data = [];


### PR DESCRIPTION
The TagsChart widget now displays only the top 30 tags by usage, sorts tag names alphabetically (case-insensitive), and formats tag names with uppercase initials for better readability.