### PR TITLE
Add global search result titles to Filament resources

### DIFF
--- a/app/Filament/Resources/BookmarkResource.php
+++ b/app/Filament/Resources/BookmarkResource.php
@@ -21,6 +21,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Tags\Tag;
@@ -142,6 +143,11 @@ class BookmarkResource extends Resource
     public static function getGlobalSearchResultUrl(Model $record): string
     {
         return BookmarkResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->title;
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/app/Filament/Resources/BookmarkTypeResource.php
+++ b/app/Filament/Resources/BookmarkTypeResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class BookmarkTypeResource extends Resource
@@ -116,6 +117,11 @@ class BookmarkTypeResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return BookmarkTypeResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/CertificationProviderResource.php
+++ b/app/Filament/Resources/CertificationProviderResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class CertificationProviderResource extends Resource
@@ -123,6 +124,11 @@ class CertificationProviderResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CertificationProviderResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/CertificationResource.php
+++ b/app/Filament/Resources/CertificationResource.php
@@ -23,6 +23,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -224,7 +225,12 @@ class CertificationResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CertificationResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/app/Filament/Resources/CertificationTypeResource.php
+++ b/app/Filament/Resources/CertificationTypeResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class CertificationTypeResource extends Resource
@@ -111,6 +112,11 @@ class CertificationTypeResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CertificationTypeResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/CompanyResource.php
+++ b/app/Filament/Resources/CompanyResource.php
@@ -20,6 +20,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class CompanyResource extends Resource
@@ -130,6 +131,11 @@ class CompanyResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CompanyResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/CourseProviderResource.php
+++ b/app/Filament/Resources/CourseProviderResource.php
@@ -20,6 +20,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class CourseProviderResource extends Resource
@@ -136,6 +137,11 @@ class CourseProviderResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CourseProviderResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/CourseResource.php
+++ b/app/Filament/Resources/CourseResource.php
@@ -26,6 +26,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Tables\Actions\CommentsAction;
@@ -176,7 +177,12 @@ class CourseResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CourseResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->title;
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/app/Filament/Resources/CurrencyResource.php
+++ b/app/Filament/Resources/CurrencyResource.php
@@ -18,6 +18,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class CurrencyResource extends Resource
@@ -106,6 +107,11 @@ class CurrencyResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return CurrencyResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/NoteResource.php
+++ b/app/Filament/Resources/NoteResource.php
@@ -21,6 +21,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Tables\Actions\CommentsAction;
@@ -134,7 +135,12 @@ class NoteResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return NoteResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->title;
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/app/Filament/Resources/ResourceCategoryResource.php
+++ b/app/Filament/Resources/ResourceCategoryResource.php
@@ -20,6 +20,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class ResourceCategoryResource extends Resource
@@ -113,6 +114,11 @@ class ResourceCategoryResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return ResourceCategoryResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/ResourceResource.php
+++ b/app/Filament/Resources/ResourceResource.php
@@ -25,6 +25,7 @@ use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Tables\Actions\CommentsAction;
@@ -190,7 +191,12 @@ class ResourceResource extends ResourcesResource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return ResourceResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/app/Filament/Resources/ToolResource.php
+++ b/app/Filament/Resources/ToolResource.php
@@ -24,6 +24,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Tables\Actions\CommentsAction;
@@ -192,9 +193,14 @@ class ToolResource extends Resource
         return ['name', 'type.name', 'url', 'git_repo_url', 'description', 'features', 'pricing'];
     }
 
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
+    }
+
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return ToolResource::getUrl('view', ['record' => $record]);
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/app/Filament/Resources/ToolTypeResource.php
+++ b/app/Filament/Resources/ToolTypeResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
 class ToolTypeResource extends Resource
@@ -109,6 +110,11 @@ class ToolTypeResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return ToolTypeResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->name;
     }
 }

--- a/app/Filament/Resources/TutorialResource.php
+++ b/app/Filament/Resources/TutorialResource.php
@@ -20,6 +20,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Tables\Actions\CommentsAction;
 use Spatie\Tags\Tag;
@@ -136,6 +137,11 @@ class TutorialResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return TutorialResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->title;
     }
 }

--- a/app/Filament/Resources/WhitepaperResource.php
+++ b/app/Filament/Resources/WhitepaperResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Parallax\FilamentComments\Tables\Actions\CommentsAction;
 
@@ -126,6 +127,11 @@ class WhitepaperResource extends Resource
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return BookmarkResource::getUrl('view', ['record' => $record]);
+        return WhitepaperResource::getUrl('view', ['record' => $record]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string | Htmlable
+    {
+        return $record->title;
     }
 }


### PR DESCRIPTION
Implemented getGlobalSearchResultTitle in all Filament resource classes to return a meaningful title for each search result. Also fixed getGlobalSearchResultUrl to use the correct resource class instead of always referencing BookmarkResource. This improves the clarity and accuracy of global search results in the admin panel.